### PR TITLE
Highlight possible wrong directory on failure

### DIFF
--- a/wpcli-lbf-setup
+++ b/wpcli-lbf-setup
@@ -103,8 +103,14 @@ siteurl=`wp option get siteurl 2> /dev/null`
 
 if [ $? -ne 0 ]
 then
-  echo "${red}Could not connect, please re-check your database settings.${normal}"
+  echo "${red}Could not connect, please re-check your database settings. Also check you're in the correct directory.${normal}"
   echo
+  echo "${yellow}Removing..${normal} ${yml_path}"
+  echo
+  rm "$yml_path";
+  echo "${yellow}Removing..${normal} ${php_path}"
+  echo
+  rm "$php_path";
   exit 1
 fi
 

--- a/wpcli-lbf-setup
+++ b/wpcli-lbf-setup
@@ -103,7 +103,7 @@ siteurl=`wp option get siteurl 2> /dev/null`
 
 if [ $? -ne 0 ]
 then
-  echo "${red}Could not connect, please re-check your database settings. Also check you're in the correct directory.${normal}"
+  echo "${red}Could not connect, please re-check your database settings and confirm you're in the correct directory.${normal}"
   echo
   exit 1
 fi

--- a/wpcli-lbf-setup
+++ b/wpcli-lbf-setup
@@ -105,12 +105,6 @@ if [ $? -ne 0 ]
 then
   echo "${red}Could not connect, please re-check your database settings. Also check you're in the correct directory.${normal}"
   echo
-  echo "${yellow}Removing..${normal} ${yml_path}"
-  echo
-  rm "$yml_path";
-  echo "${yellow}Removing..${normal} ${php_path}"
-  echo
-  rm "$php_path";
   exit 1
 fi
 


### PR DESCRIPTION
I added a couple of lines to delete the `wp-cli.local.yml` and `wp-cli.local.php` if it can't connect successfully.

I also changed the error message to include a note about being in the right directory. A couple of times I wondered why it wasn't connecting and realised I had executed the script in a wrong directory.